### PR TITLE
Please add these license files to the jars to make them redistributable

### DIFF
--- a/src/main/java/LICENSE-XmlPullParser.txt
+++ b/src/main/java/LICENSE-XmlPullParser.txt
@@ -1,0 +1,59 @@
+/*
+ * Indiana University Extreme! Lab Software License, Version 1.2
+ *
+ * Copyright (C) 2004 The Trustees of Indiana University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1) All redistributions of source code must retain the above
+ *    copyright notice, the list of authors in the original source
+ *    code, this list of conditions and the disclaimer listed in this
+ *    license;
+ *
+ * 2) All redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the disclaimer
+ *    listed in this license in the documentation and/or other
+ *    materials provided with the distribution;
+ *
+ * 3) Any documentation included with all redistributions must include
+ *    the following acknowledgement:
+ *
+ *      "This product includes software developed by the Indiana
+ *      University Extreme! Lab.  For further information please visit
+ *      http://www.extreme.indiana.edu/"
+ *
+ *    Alternatively, this acknowledgment may appear in the software
+ *    itself, and wherever such third-party acknowledgments normally
+ *    appear.
+ *
+ * 4) The name "Indiana University" or "Indiana University
+ *    Extreme! Lab" shall not be used to endorse or promote
+ *    products derived from this software without prior written
+ *    permission from Indiana University.  For written permission,
+ *    please contact http://www.extreme.indiana.edu/.
+ *
+ * 5) Products derived from this software may not use "Indiana
+ *    University" name nor may "Indiana University" appear in their name,
+ *    without prior written permission of the Indiana University.
+ *
+ * Indiana University provides no reassurances that the source code
+ * provided does not infringe the patent or any other intellectual
+ * property rights of any other entity.  Indiana University disclaims any
+ * liability to any recipient for claims brought by any other entity
+ * based on infringement of intellectual property rights or otherwise.
+ *
+ * LICENSEE UNDERSTANDS THAT SOFTWARE IS PROVIDED "AS IS" FOR WHICH
+ * NO WARRANTIES AS TO CAPABILITIES OR ACCURACY ARE MADE. INDIANA
+ * UNIVERSITY GIVES NO WARRANTIES AND MAKES NO REPRESENTATION THAT
+ * SOFTWARE IS FREE OF INFRINGEMENT OF THIRD PARTY PATENT, COPYRIGHT, OR
+ * OTHER PROPRIETARY RIGHTS.  INDIANA UNIVERSITY MAKES NO WARRANTIES THAT
+ * SOFTWARE IS FREE FROM "BUGS", "VIRUSES", "TROJAN HORSES", "TRAP
+ * DOORS", "WORMS", OR OTHER HARMFUL CODE.  LICENSEE ASSUMES THE ENTIRE
+ * RISK AS TO THE PERFORMANCE OF SOFTWARE AND/OR ASSOCIATED MATERIALS,
+ * AND TO THE PERFORMANCE AND VALIDITY OF INFORMATION GENERATED USING
+ * SOFTWARE.
+ */
+

--- a/src/main/java/LICENSE.txt
+++ b/src/main/java/LICENSE.txt
@@ -1,0 +1,21 @@
+Force.com Web Service Connector End User License Agreement
+
+Except as described below, Force.com Web Service Connector (WSC) is Copyright (c) 2005-2012, salesforce.com, inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The following Third Party components are licensed as follows:
+Xml Pull Parser
+
+    MXParser.java
+    MXSerializer.java
+    XmlPullParser.java
+    XmlPullParserException.java
+
+Your use of the Xml Pull Parser code is subject to the terms and conditions of the Indiana University Extreme! Lab Software License, Version 1.2, available at http://extreme.indiana.edu/license.txt


### PR DESCRIPTION
These files will appear in the root of the generated jar files, which is
essential to make the binary jar file redistributable.  (The -with-dependencies jar file would need additional information in LICENSE.txt about Rhino, and a LICENSE-Rhino.txt file.  I could not easily figure out how to make the two artifacts differ, so I deferred that task.)

Without these files, most legal departments will recommend against redistributing the jar files, which complicates greatly selling a third-party solution that integrates with Force.com.  With these files, the jar files become redistributable, making integrations easier to package, sell and install.

I'm not terribly proficient with Maven, so if there is a better way to add files to these jar files, please let me know and I'll take a stab at it.

Thanks in advance for taking the time to review this proposed change.

-aB
