### PR TITLE
#26 - findField() can stay in children scan cycle unnecessarily long

### DIFF
--- a/src/main/java/com/sforce/ws/bind/XmlObject.java
+++ b/src/main/java/com/sforce/ws/bind/XmlObject.java
@@ -189,6 +189,7 @@ public class XmlObject implements XMLizable {
         for (XmlObject child : children) {
             if (child.getName().getLocalPart().equals(name)) {
                 item = child;
+                break;
             }
         }
 


### PR DESCRIPTION
XmlObject.findField(name) should break out of the cycle as soon as the child with requested name is found
