### PR TITLE
Fix 'uber' .jar reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To skip the gpg signing, run the following command
     mvn clean package -Dgpg.skip
 
 ## Generating Stubs From WSDLs
-    java -classpath target/force-wsc-29.0.0-jar-with-dependencies.jar com.sforce.ws.tools.wsdlc <inputwsdlfile> <outputjarfile>
+    java -classpath target/force-wsc-29.0.0-uber.jar com.sforce.ws.tools.wsdlc <inputwsdlfile> <outputjarfile>
 
 * `inputwsdlfile` is the name of the WSDL to generate stubs for.
 * `outputjarfile` is the name of the jar file to create from the WSDL.


### PR DESCRIPTION
The README.md currently references a '-with-dependencies' .jar in its
instructions for generating classes from a WSDL. This .jar is in fact
build as '-uber' rather than '-with-dependencies'
