### PR TITLE
Added exception handler to TypeMapper. The handler is a no-op that

### DIFF
--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -666,6 +666,13 @@ public class TypeMapper {
                 s = enumStrValue;
             }
         }
+    	catch(NoSuchFieldException e) {
+    		// Do nothing.
+    		// It's possible that this type mapper is being used with stubs that were not
+    		// generated from templates that add the valuesToEnums field. So, catching
+    		// this exception and then doing nothing is a way to default back to the old
+    		// behavior in which enums with hyphens are not supported.
+    	}
         catch(Exception e) {
         	throw new ConnectionException("Failed to read enum", e);
         }


### PR DESCRIPTION
catches the NoSuchFieldException exception that would be thrown if an
attempt was made to read an enum using a stub that had not been
generated from the new WSC template scheme. Basically, the handler
enables TypeMapper.readEnum to degrade back to the old readEnum behavior
where enums could not include hyphens.
