### PR TITLE
Getter for field references in SObject

### DIFF
--- a/src/main/java/com/sforce/async/SObject.java
+++ b/src/main/java/com/sforce/async/SObject.java
@@ -63,6 +63,10 @@ public final class SObject {
         fkRefs.put(name, ref);
     }
 
+    public Map<String, SObject> getFieldReferences() {
+        return Collections.unmodifiableMap(fkRefs);
+    }
+
     /**
      * Example:
      * <?xml version="1.0" encoding="UTF-8"?>

--- a/src/main/java/com/sforce/async/SObject.java
+++ b/src/main/java/com/sforce/async/SObject.java
@@ -63,10 +63,6 @@ public final class SObject {
         fkRefs.put(name, ref);
     }
 
-    public Map<String, SObject> getFieldReferences() {
-        return Collections.unmodifiableMap(fkRefs);
-    }
-
     /**
      * Example:
      * <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The purpose of this change is to facilitate traversal of the SObject tree.