### PR TITLE
cannot build ,error:NoGoalSpecifiedException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     </dependency>
   </dependencies>
   <build>
+  <defaultGoal>install</defaultGoal>
     <resources>
       <resource>
         <filtering>false</filtering>


### PR DESCRIPTION
when run "mvn clean package -Dgpg.skip" command to skip the gpg signing, 

the maven will throw a exception : .NoGoalSpecifiedException.

add "<defaultGoal>install</defaultGoal>" to fix this error.