### PR TITLE
String array support

### DIFF
--- a/src/main/java/com/sforce/ws/bind/ArrayCodec.java
+++ b/src/main/java/com/sforce/ws/bind/ArrayCodec.java
@@ -1,0 +1,107 @@
+package com.sforce.ws.bind;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.appengine.repackaged.com.google.common.base.Joiner;
+import com.google.appengine.repackaged.com.google.common.base.Splitter;
+
+/**
+ * For embedding non-XML serialization of basic arrays within an XML document.
+ * This treats the array as an atomic data-type which occupies a leaf-node on
+ * the document tree.
+ *
+ * This should handle any T where "t equals new T( t.toString() )
+ * @author wgray
+ */
+public class ArrayCodec {
+
+	private static final String UTF8 = "UTF-8";
+
+	/** Uses toString() to yield string serialization.
+	 *  Expects new X( String ) for deserialization. */
+	public <T> String getValueAsString( Class<T> componentType, Object value ) {
+		validateComponentType( componentType );
+		try {
+			Object[] array = (Object[])value;
+			List<String> encoded = new ArrayList<String>( array.length );
+	    	for( Object obj: array ) {
+	    		if( obj == null ) {
+	    			encoded.add( null );
+	    		} else {
+    				encoded.add( '"' + URLEncoder.encode( obj.toString(), UTF8 ) + '"' );
+	    		}
+	    	}
+	    	return "[" + Joiner.on(",").useForNull( "null" ).join( encoded ) + "]";
+		} catch( UnsupportedEncodingException e ) {
+			throw new RuntimeException( "Cannot encode array", e );
+		}
+	}
+
+	public <T> T[] deserialize( Class<T> componentType, String source ) {
+		if( source == null ) {
+			throw new ArrayCodecException( "Unable to parse array." );
+		}
+    	List<T> result = new ArrayList<T>();
+		source = trimEnclosing( source, '[', ']' ).trim();
+		if( source.length() > 0 ) {
+			List<String> encoded = Splitter.on( "," ).splitToList( source );
+	    	for( String s: encoded ) {
+	    		if( "null".equals( s )) {
+	    			result.add( null );
+	    		} else {
+	    	    	try {
+	    	    		s = trimEnclosing( s, '"', '"' );
+	    	    		s = URLDecoder.decode( s, UTF8 );
+						T t = (T)componentType.getConstructor( String.class ).newInstance( s );
+		    			result.add( t );
+	    	    	} catch( Exception e ) {
+	    				throw new ArrayCodecException( "Cannot parse array", e );
+	    	    	}
+	    		}
+	    	}
+		}
+    	@SuppressWarnings("unchecked")
+    	T[] t = (T[])result.toArray();
+    	return t;
+    }
+
+	private String trimEnclosing( String source, char open, char close ) {
+		if( source.charAt( 0 ) != open || source.charAt( source.length() - 1 ) != close ) {
+			throw new ArrayCodecException( "Cannot trim enclosing characters." );
+		}
+		return source.substring( 1, source.length() - 1 );
+	}
+
+//    	ByteArrayOutputStream baos = new ByteArrayOutputStream();
+//    	java.beans.XMLEncoder enc = new java.beans.XMLEncoder(baos);
+//    	enc.writeObject(array);
+//    	enc.close();
+//    	return new String( baos.toByteArray() );
+
+	private <T> void validateComponentType( Class<T> type ) {
+		// No multi-dimensioned arrays
+		if( type.isArray() ) throw new ArrayCodecException( "Multi-dimensional arrays not supported." );
+		// Must have constructor that takes String
+		try {
+			type.getConstructor( String.class );
+		} catch( NoSuchMethodException e ) {
+			throw new ArrayCodecException( "Cannot find suitable constructor" );
+		}
+	}
+
+    @SuppressWarnings("serial")
+	public static class ArrayCodecException extends RuntimeException {
+		public ArrayCodecException( String message ) {
+			super( message );
+		}
+
+    	public ArrayCodecException( String message, Throwable th ) {
+    		super( message, th );
+    	}
+    }
+
+}

--- a/src/main/java/com/sforce/ws/bind/ArrayCodec.java
+++ b/src/main/java/com/sforce/ws/bind/ArrayCodec.java
@@ -19,89 +19,83 @@ import com.google.appengine.repackaged.com.google.common.base.Splitter;
  */
 public class ArrayCodec {
 
-	private static final String UTF8 = "UTF-8";
+    private static final String UTF8 = "UTF-8";
 
-	/** Uses toString() to yield string serialization.
-	 *  Expects new X( String ) for deserialization. */
-	public <T> String getValueAsString( Class<T> componentType, Object value ) {
-		validateComponentType( componentType );
-		try {
-			Object[] array = (Object[])value;
-			List<String> encoded = new ArrayList<String>( array.length );
-	    	for( Object obj: array ) {
-	    		if( obj == null ) {
-	    			encoded.add( null );
-	    		} else {
-    				encoded.add( '"' + URLEncoder.encode( obj.toString(), UTF8 ) + '"' );
-	    		}
-	    	}
-	    	return "[" + Joiner.on(",").useForNull( "null" ).join( encoded ) + "]";
-		} catch( UnsupportedEncodingException e ) {
-			throw new RuntimeException( "Cannot encode array", e );
-		}
-	}
-
-	public <T> T[] deserialize( Class<T> componentType, String source ) {
-		if( source == null ) {
-			throw new ArrayCodecException( "Unable to parse array." );
-		}
-    	List<T> result = new ArrayList<T>();
-		source = trimEnclosing( source, '[', ']' ).trim();
-		if( source.length() > 0 ) {
-			List<String> encoded = Splitter.on( "," ).splitToList( source );
-	    	for( String s: encoded ) {
-	    		if( "null".equals( s )) {
-	    			result.add( null );
-	    		} else {
-	    	    	try {
-	    	    		s = trimEnclosing( s, '"', '"' );
-	    	    		s = URLDecoder.decode( s, UTF8 );
-						T t = (T)componentType.getConstructor( String.class ).newInstance( s );
-		    			result.add( t );
-	    	    	} catch( Exception e ) {
-	    				throw new ArrayCodecException( "Cannot parse array", e );
-	    	    	}
-	    		}
-	    	}
-		}
-    	@SuppressWarnings("unchecked")
-    	T[] t = (T[])result.toArray();
-    	return t;
+    /** Uses toString() to yield string serialization.
+     *  Expects new X( String ) for deserialization. */
+    public <T> String getValueAsString( Class<T> componentType, Object value ) {
+        validateComponentType( componentType );
+        try {
+            Object[] array = (Object[])value;
+            List<String> encoded = new ArrayList<String>( array.length );
+            for( Object obj: array ) {
+                if( obj == null ) {
+                    encoded.add( null );
+                } else {
+                    encoded.add( '"' + URLEncoder.encode( obj.toString(), UTF8 ) + '"' );
+                }
+            }
+            return "[" + Joiner.on(",").useForNull( "null" ).join( encoded ) + "]";
+        } catch( UnsupportedEncodingException e ) {
+            throw new RuntimeException( "Cannot encode array", e );
+        }
     }
 
-	private String trimEnclosing( String source, char open, char close ) {
-		if( source.charAt( 0 ) != open || source.charAt( source.length() - 1 ) != close ) {
-			throw new ArrayCodecException( "Cannot trim enclosing characters." );
-		}
-		return source.substring( 1, source.length() - 1 );
-	}
+    public <T> T[] deserialize( Class<T> componentType, String source ) {
+        if( source == null ) {
+            throw new ArrayCodecException( "Unable to parse null array." );
+        }
+        List<T> result = new ArrayList<T>();
+        source = trimEnclosing( source, '[', ']' ).trim();
+        if( source.length() > 0 ) {
+            List<String> encoded = Splitter.on( "," ).splitToList( source );
+            for( String s: encoded ) {
+                if( "null".equals( s )) {
+                    result.add( null );
+                } else {
+                    try {
+                        s = trimEnclosing( s, '"', '"' );
+                        s = URLDecoder.decode( s, UTF8 );
+                        T t = (T)componentType.getConstructor( String.class ).newInstance( s );
+                        result.add( t );
+                    } catch( Exception e ) {
+                        throw new ArrayCodecException( "Cannot parse array", e );
+                    }
+                }
+            }
+        }
+        @SuppressWarnings("unchecked")
+        T[] t = (T[])result.toArray();
+        return t;
+    }
 
-//    	ByteArrayOutputStream baos = new ByteArrayOutputStream();
-//    	java.beans.XMLEncoder enc = new java.beans.XMLEncoder(baos);
-//    	enc.writeObject(array);
-//    	enc.close();
-//    	return new String( baos.toByteArray() );
+    private String trimEnclosing( String source, char open, char close ) {
+        if( source.charAt( 0 ) != open || source.charAt( source.length() - 1 ) != close ) {
+            throw new ArrayCodecException( "Cannot trim enclosing characters." );
+        }
+        return source.substring( 1, source.length() - 1 );
+    }
 
-	private <T> void validateComponentType( Class<T> type ) {
-		// No multi-dimensioned arrays
-		if( type.isArray() ) throw new ArrayCodecException( "Multi-dimensional arrays not supported." );
-		// Must have constructor that takes String
-		try {
-			type.getConstructor( String.class );
-		} catch( NoSuchMethodException e ) {
-			throw new ArrayCodecException( "Cannot find suitable constructor" );
-		}
-	}
+    private <T> void validateComponentType( Class<T> type ) {
+        // No multi-dimensioned arrays
+        if( type.isArray() ) throw new ArrayCodecException( "Multi-dimensional arrays not supported." );
+        // Must have constructor that takes String
+        try {
+            type.getConstructor( String.class );
+        } catch( NoSuchMethodException e ) {
+            throw new ArrayCodecException( "Cannot find suitable constructor" );
+        }
+    }
 
     @SuppressWarnings("serial")
-	public static class ArrayCodecException extends RuntimeException {
-		public ArrayCodecException( String message ) {
-			super( message );
-		}
+    public static class ArrayCodecException extends RuntimeException {
+        public ArrayCodecException( String message ) {
+            super( message );
+        }
 
-    	public ArrayCodecException( String message, Throwable th ) {
-    		super( message, th );
-    	}
+        public ArrayCodecException( String message, Throwable th ) {
+            super( message, th );
+        }
     }
 
 }

--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -72,6 +72,7 @@ public class TypeMapper {
     private static HashMap<String, QName> getJavaXmlMapping() {
         HashMap<String, QName> map = new HashMap<String, QName>();
         map.put(String.class.getName(), new QName(Constants.SCHEMA_NS, "string"));
+        map.put(String[].class.getName(), new QName(Constants.SCHEMA_NS, "stringArray"));
         map.put(int.class.getName(), new QName(Constants.SCHEMA_NS, "int"));
         map.put(Integer.class.getName(), new QName(Constants.SCHEMA_NS, "int"));
         map.put(boolean.class.getName(), new QName(Constants.SCHEMA_NS, "boolean"));
@@ -94,6 +95,7 @@ public class TypeMapper {
     private static HashMap<QName, String> getXmlJavaMapping() {
         HashMap<QName, String> map = new HashMap<QName, String>();
         map.put(new QName(Constants.SCHEMA_NS, "string"), String.class.getName());
+        map.put(new QName(Constants.SCHEMA_NS, "stringArray"), String[].class.getName());
         map.put(new QName(Constants.SCHEMA_NS, "int"), int.class.getName());
         map.put(new QName(Constants.SCHEMA_NS, "long"), long.class.getName());
         map.put(new QName(Constants.SCHEMA_NS, "float"), float.class.getName());
@@ -671,7 +673,7 @@ public class TypeMapper {
 
     private String readEnum(XmlInputStream in, TypeInfo typeInfo, Class<?> type) throws IOException, ConnectionException {
         String s = readString(in, typeInfo, type);
-        
+
         // This block of code has been added to enable stubs to deserialize enum values
         // that contain hyphens (e.g. UTF-8). The mdapi schema contains such enums
         // (e.g. the Encoding enumeration).
@@ -696,7 +698,7 @@ public class TypeMapper {
         catch(Exception e) {
         	throw new ConnectionException("Failed to read enum", e);
         }
-        
+
         int index = s.indexOf(":");
         String token = index == -1 ? s : s.substring(index + 1);
         return isKeyWord(token) ? "_" + token : token;

--- a/src/main/java/com/sforce/ws/bind/XmlObject.java
+++ b/src/main/java/com/sforce/ws/bind/XmlObject.java
@@ -28,6 +28,7 @@ package com.sforce.ws.bind;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import javax.xml.namespace.QName;
@@ -246,8 +247,8 @@ public class XmlObject implements XMLizable {
             			throw new IOException("Unable to find xml type for :" + value.getClass().getName());
             		}
             		int max = value.getClass().isArray() ? -1 : 1;
-            		if (value.getClass().getName().equals("[B")) {
-            			//special case for byte[]
+            		if (Arrays.<Class<?>>asList( byte[].class, String[].class ).contains( value.getClass() )) {
+            			//special case for arrays we wish to treat as a single value
             			max = 1;
             		}
             		info = new TypeInfo(name.getNamespaceURI(), name.getLocalPart(),

--- a/src/test/java/com/sforce/ws/bind/ArrayCodecTest.java
+++ b/src/test/java/com/sforce/ws/bind/ArrayCodecTest.java
@@ -1,0 +1,23 @@
+package com.sforce.ws.bind;
+
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+
+public class ArrayCodecTest extends TestCase {
+
+    public void testStringArray() throws Exception {
+        String[][] data = new String[][] {
+                { "a","b" }, {}, { ",<&>!\"" }, { null, "", null }, {"\u269d","\26ab" }
+        };
+
+        ArrayCodec codec = new ArrayCodec();
+
+        for( String[] d: data ) {
+            String source = codec.getValueAsString( String.class, d );
+            Object result = codec.deserialize(String.class, source);
+            assertTrue( result.getClass().isArray() );
+            assertTrue( Arrays.equals(d, (Object[])result));
+        }
+    }
+}

--- a/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
+++ b/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
@@ -67,6 +67,11 @@ public class XmlObjectTest extends TestCase {
         obj.setValue(new MyDate());
         obj.write(qname, xout, typeMapper);
 
+        // Then try String[]
+        obj = new XmlObject(qname);
+        obj.setValue(new String[] {"a","b" });
+        obj.write(qname, xout, typeMapper);
+
         // Then try some non-mappable subclass
         obj = new XmlObject(qname);
         obj.setValue(new AtomicLong(10L));
@@ -82,35 +87,31 @@ public class XmlObjectTest extends TestCase {
     	QName qname = new QName( "type", "sobject.partner.soap.sforce.com" );
     	TypeMapper typeMapper = new TypeMapper();
 
-    	String[][] data = new String[][] {
-    			{ "a","b" }, {}, { ",<&>!\"" }, { null, "", null }
-    	};
+    	String[] ab = new String[] { "a","b" };
+		XmlObject obj = new XmlObject( qname );
+		obj.setValue( ab );
 
-    	for( String[] d: data ) {
-    		// Serialize
-    		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        	XmlOutputStream xout = new XmlOutputStream( baos, true );
-        	xout.startDocument();
-        	xout.writeStartTag("", "start");
-    		XmlObject obj = new XmlObject( qname );
-    		obj.setValue( d );
-    		obj.write( qname,  xout,  typeMapper );
-    		xout.writeEndTag("", "start");
-    		xout.close();
+		// Serialize
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    	XmlOutputStream xout = new XmlOutputStream( baos, true );
+    	xout.startDocument();
+    	xout.writeStartTag("", "start");
+		obj.write( qname,  xout,  typeMapper );
+		xout.writeEndTag("", "start");
+		xout.close();
 
-    		// Parse
-    		ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
-    		XmlInputStream xin = new XmlInputStream();
-    		xin.setInput( bais, "UTF-8" );
-    		xin.nextTag();
-    		XmlObject parsed = new XmlObject( qname );
-    		parsed.load( xin, typeMapper );
-    		parsed = parsed.getChildren().next();
-    		Object result = parsed.getValue();
+		// Parse
+		ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
+		XmlInputStream xin = new XmlInputStream();
+		xin.setInput( bais, "UTF-8" );
+		xin.nextTag();
+		XmlObject parsed = new XmlObject( qname );
+		parsed.load( xin, typeMapper );
+		parsed = parsed.getChildren().next();
+		Object result = parsed.getValue();
 
-    		// Assert
-    		assertTrue( result.getClass().isArray() );
-    		assertTrue( Arrays.equals(d, (Object[])result));
-    	}
+		// Assert
+		assertTrue( result.getClass().isArray() );
+		assertTrue( Arrays.equals(ab, (Object[])result));
     }
 }

--- a/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
+++ b/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
@@ -26,16 +26,19 @@
 
 package com.sforce.ws.bind;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.xml.namespace.QName;
 
-import com.sforce.ws.parser.XmlOutputStream;
-
 import junit.framework.Assert;
 import junit.framework.TestCase;
+
+import com.sforce.ws.parser.XmlInputStream;
+import com.sforce.ws.parser.XmlOutputStream;
 
 /**
  * XmlObjectTest -- Validates that subclasses of basic types can be serialized
@@ -57,12 +60,12 @@ public class XmlObjectTest extends TestCase {
         XmlObject obj = new XmlObject(qname);
         obj.setValue(new Date());
         obj.write(qname, xout, typeMapper);
-        
+
         // Then try subclass of Date
         obj = new XmlObject(qname);
         obj.setValue(new MyDate());
         obj.write(qname, xout, typeMapper);
-        
+
         // Then try some non-mappable subclass
         obj = new XmlObject(qname);
         obj.setValue(new AtomicLong(10L));
@@ -72,5 +75,45 @@ public class XmlObjectTest extends TestCase {
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Unable to find xml type for"));
         }
+    }
+
+    private static class Foo { int x=0; public int getX() { return x; }
+    public String toString() { return ""+x; };
+    public boolean equals( Object a ) { return a instanceof Foo && ((Foo)a).getX() == this.getX(); } }
+    public void testStringArray() throws Exception {
+    	QName qname = new QName( "type", "sobject.partner.soap.sforce.com" );
+    	TypeMapper typeMapper = new TypeMapper();
+
+//    	String[][] data = new String[][] { {"a","b"} };
+//    			{ "a","b" }, {}, { "<&>!" }
+//    	};
+    	String[] xx = { "a","b" };
+    	Object[] data = new Object[] { xx };
+
+    	for( Object d: data ) {
+    		// Serialize
+    		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        	XmlOutputStream xout = new XmlOutputStream( baos, true );
+        	xout.startDocument();
+        	xout.writeStartTag("", "start");
+    		XmlObject obj = new XmlObject( qname );
+    		obj.setValue( d );
+    		obj.write( qname,  xout,  typeMapper );
+    		xout.writeEndTag("", "start");
+    		xout.close();
+
+    		System.out.println( new String(baos.toByteArray(),"UTF-8"));
+    		// Parse
+    		ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
+    		XmlInputStream xin = new XmlInputStream();
+    		xin.setInput( bais, "UTF-8" );
+    		xin.nextTag();
+    		XmlObject parsed = new XmlObject( qname );
+    		parsed.load( xin, typeMapper );
+    		parsed = parsed.getChildren().next().getChildren().next();
+    		System.out.println( parsed.toString() );
+
+    		assertEquals( d, parsed.getValue() );
+    	}
     }
 }

--- a/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
+++ b/src/test/java/com/sforce/ws/bind/XmlObjectTest.java
@@ -29,6 +29,7 @@ package com.sforce.ws.bind;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -77,20 +78,15 @@ public class XmlObjectTest extends TestCase {
         }
     }
 
-    private static class Foo { int x=0; public int getX() { return x; }
-    public String toString() { return ""+x; };
-    public boolean equals( Object a ) { return a instanceof Foo && ((Foo)a).getX() == this.getX(); } }
     public void testStringArray() throws Exception {
     	QName qname = new QName( "type", "sobject.partner.soap.sforce.com" );
     	TypeMapper typeMapper = new TypeMapper();
 
-//    	String[][] data = new String[][] { {"a","b"} };
-//    			{ "a","b" }, {}, { "<&>!" }
-//    	};
-    	String[] xx = { "a","b" };
-    	Object[] data = new Object[] { xx };
+    	String[][] data = new String[][] {
+    			{ "a","b" }, {}, { ",<&>!\"" }, { null, "", null }
+    	};
 
-    	for( Object d: data ) {
+    	for( String[] d: data ) {
     		// Serialize
     		ByteArrayOutputStream baos = new ByteArrayOutputStream();
         	XmlOutputStream xout = new XmlOutputStream( baos, true );
@@ -102,7 +98,6 @@ public class XmlObjectTest extends TestCase {
     		xout.writeEndTag("", "start");
     		xout.close();
 
-    		System.out.println( new String(baos.toByteArray(),"UTF-8"));
     		// Parse
     		ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
     		XmlInputStream xin = new XmlInputStream();
@@ -110,10 +105,12 @@ public class XmlObjectTest extends TestCase {
     		xin.nextTag();
     		XmlObject parsed = new XmlObject( qname );
     		parsed.load( xin, typeMapper );
-    		parsed = parsed.getChildren().next().getChildren().next();
-    		System.out.println( parsed.toString() );
+    		parsed = parsed.getChildren().next();
+    		Object result = parsed.getValue();
 
-    		assertEquals( d, parsed.getValue() );
+    		// Assert
+    		assertTrue( result.getClass().isArray() );
+    		assertTrue( Arrays.equals(d, (Object[])result));
     	}
     }
 }


### PR DESCRIPTION
Support for String[] as an atomic value.  

In a perfect world, we would use a ready-built codec, such as in Axis, or even java.beans.  However, The data-flow does not easily allow insertion of additional nodes to the XML out stream, as it assumes any value is immediately serializable to a String, which is subsequently escaped when injected into the document.

As an alternative, a simple codec using URL-encoding allows us to freely use non-alpha characters in our serialization (specifically [,]").  This allows for a readable XML document and fits into the existing architecture of the client.

A third alternative, involved converting String->byte[]->Base64, but this was rejected as it would render the output XML unreadable.