### PR TITLE
Deserialize dates in UTC timezone

### DIFF
--- a/src/main/java/com/sforce/ws/bind/DateCodec.java
+++ b/src/main/java/com/sforce/ws/bind/DateCodec.java
@@ -43,6 +43,7 @@ package com.sforce.ws.bind;
  */
 
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -62,6 +63,9 @@ public class DateCodec {
             new SimpleDateFormat("yyyy-MM-dd");
     //  0123456789 0 123456789
 
+    static {
+        zulu.setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
 
     public String getValueAsString(Object value) {
         Date date = value instanceof Date ? (Date) value : ((Calendar) value).getTime();


### PR DESCRIPTION
According to sfdc documentation, dates in the soap api are transmitted in UTC.

The connector is correctly serializing them in UTC in the CalendarCodec class, but is deserializing using local time in the DateCodec class. 