### PR TITLE
Include uber jar in deploy and fix Javadoc issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,9 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.7</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadoc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>uber</shadedClassifierName>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When running deploy, include the uber jar.
Fix the Javadoc issue on JDK 8 where it would error out.

Should be two pull requests, but oops.