### PR TITLE
Making the XmlOutputStream AutoCloseable for convenience

### DIFF
--- a/src/main/java/com/sforce/ws/parser/XmlOutputStream.java
+++ b/src/main/java/com/sforce/ws/parser/XmlOutputStream.java
@@ -39,7 +39,7 @@ import com.sforce.ws.wsdl.Constants;
  * @version 1.0
  * @since 1.0  Nov 30, 2005
  */
-public class XmlOutputStream {
+public class XmlOutputStream implements AutoCloseable {
     private MXSerializer serializer = new MXSerializer();
     private OutputStream out;
 
@@ -116,6 +116,7 @@ public class XmlOutputStream {
         serializer.flush();
     }
 
+    @Override
     public void close() throws IOException {
         flush();
         out.close();


### PR DESCRIPTION
It would be helpful to be able to use try-with-resources on XmlOutputStreams.