### PR TITLE
More JSON support for Bulk API in WSC

### DIFF
--- a/src/main/java/com/sforce/async/BatchRequest.java
+++ b/src/main/java/com/sforce/async/BatchRequest.java
@@ -79,7 +79,7 @@ public class BatchRequest {
             if (transport.isSuccessful()) {
                 return loadBatchInfo(in);
             } else {
-                BulkConnection.parseAndThrowException(in);
+                BulkConnection.parseAndThrowException(in, ContentType.XML);
             }
         } catch(IOException e) {
             throw new AsyncApiException("Failed to complete request", AsyncExceptionCode.ClientInputError, e);

--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -26,22 +26,40 @@
 
 package com.sforce.async;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.zip.*;
-
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import javax.xml.namespace.QName;
 
-import com.sforce.ws.*;
+import com.sforce.ws.ConnectionException;
+import com.sforce.ws.ConnectorConfig;
+import com.sforce.ws.MessageHandler;
+import com.sforce.ws.MessageHandlerWithHeaders;
+import com.sforce.ws.bind.CalendarCodec;
 import com.sforce.ws.bind.TypeMapper;
-import com.sforce.ws.parser.*;
+import com.sforce.ws.parser.PullParserException;
+import com.sforce.ws.parser.XmlInputStream;
+import com.sforce.ws.parser.XmlOutputStream;
 import com.sforce.ws.transport.Transport;
 import com.sforce.ws.util.FileUtil;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.*;
-import com.sforce.ws.bind.CalendarCodec;
 
 
 /**
@@ -141,7 +159,7 @@ public class BulkConnection {
                     return result;
                 }
             } else {
-                parseAndThrowException(in);
+                parseAndThrowException(in, contentType);
             }
         } catch (PullParserException e) {
             throw new AsyncApiException("Failed to create job ", AsyncExceptionCode.ClientInputError, e);
@@ -153,14 +171,22 @@ public class BulkConnection {
         return null;
     }
 
-    static void parseAndThrowException(InputStream in) throws AsyncApiException {
+    static void parseAndThrowException(InputStream in, ContentType type) throws AsyncApiException {
         try {
-            AsyncApiException exception = new AsyncApiException();
+            AsyncApiException exception;
+            if (type == ContentType.XML || type == ContentType.ZIP_XML || type == ContentType.CSV || type == ContentType.ZIP_CSV) {
+                exception = new AsyncApiException();
 
-            XmlInputStream xin = new XmlInputStream();
-            xin.setInput(in, "UTF-8");
+                XmlInputStream xin = new XmlInputStream();
+                xin.setInput(in, "UTF-8");
 
-            exception.load(xin, typeMapper);
+                exception.load(xin, typeMapper);
+            } else if (type == ContentType.JSON || type == ContentType.ZIP_JSON) {
+                JsonParser parser = factory.createJsonParser(in);
+                exception = parser.readValueAs(AsyncApiException.class);
+            } else {
+                throw new AsyncApiException("Server error returned in unknown format", AsyncExceptionCode.ClientInputError);
+            }
             throw exception;
 
         } catch (PullParserException e) {
@@ -205,7 +231,7 @@ public class BulkConnection {
             FileUtil.copy(input, out);
 
             InputStream result = transport.getContent();
-            if (!transport.isSuccessful()) parseAndThrowException(result);
+            if (!transport.isSuccessful()) parseAndThrowException(result, jobInfo.getContentType());
             //xml/json content type
             if (jobInfo.getContentType() == ContentType.JSON || jobInfo.getContentType() == ContentType.ZIP_JSON)
                 return deserializeJsonToObject(result, BatchInfo.class);
@@ -331,7 +357,7 @@ public class BulkConnection {
             FileUtil.copy(input, out);
 
             InputStream result = transport.getContent();
-            if (!transport.isSuccessful()) parseAndThrowException(result);
+            if (!transport.isSuccessful()) parseAndThrowException(result, jobInfo.getContentType());
             return BatchRequest.loadBatchInfo(result);
         } catch (IOException e) {
             throw new AsyncApiException("Failed to create batch", AsyncExceptionCode.ClientInputError, e);
@@ -365,7 +391,7 @@ public class BulkConnection {
             FileUtil.copy(input, out);
 
             InputStream result = transport.getContent();
-            if (!transport.isSuccessful()) parseAndThrowException(result);
+            if (!transport.isSuccessful()) parseAndThrowException(result, jobInfo.getContentType());
         } catch (IOException e) {
             throw new AsyncApiException("Failed to create transformation specification", AsyncExceptionCode.ClientInputError, e);
         } catch (ConnectionException e) {
@@ -709,7 +735,13 @@ public class BulkConnection {
         }
 
         if (!success) {
-            parseAndThrowException(in);
+            ContentType type = null;
+            if (connection.getContentType().contains(XML_CONTENT_TYPE)) {
+                type = ContentType.XML;
+            } else if (connection.getContentType().contains(JSON_CONTENT_TYPE)) {
+                type = ContentType.JSON;
+            }
+            parseAndThrowException(in, type);
         }
 
         return in;

--- a/src/main/java/com/sforce/async/CsvBatchRequest.java
+++ b/src/main/java/com/sforce/async/CsvBatchRequest.java
@@ -90,7 +90,7 @@ public class CsvBatchRequest {
             if (transport.isSuccessful()) {
                 return BatchRequest.loadBatchInfo(in);
             } else {
-                BulkConnection.parseAndThrowException(in);
+                BulkConnection.parseAndThrowException(in, ContentType.CSV);
             }
         } catch(IOException e) {
             throw new AsyncApiException("Failed to complete request", AsyncExceptionCode.ClientInputError, e);

--- a/src/main/java/com/sforce/async/TransformationSpecRequest.java
+++ b/src/main/java/com/sforce/async/TransformationSpecRequest.java
@@ -78,7 +78,7 @@ public class TransformationSpecRequest {
 
             InputStream result = transport.getContent();
             if (!transport.isSuccessful()) {
-                BulkConnection.parseAndThrowException(result);
+                BulkConnection.parseAndThrowException(result, ContentType.CSV);
             }
         } catch(IOException e) {
             throw new AsyncApiException("Failed to complete request", AsyncExceptionCode.ClientInputError, e);

--- a/src/test/java/com/sforce/async/BulkConnectionTest.java
+++ b/src/test/java/com/sforce/async/BulkConnectionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright, 2015, salesforce.com
+ * All Rights Reserved
+ * Company Confidential
+ */
+package com.sforce.async;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This is the beginning of a unit test class for {@link BulkConnection}.
+ *
+ * @author btajuddin-sfdc
+ */
+public class BulkConnectionTest {
+
+    @Test
+    public void testParseAndThrowXml() {
+        InputStream inputStream = new ByteArrayInputStream(("<error xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n" +
+                "<exceptionCode>InvalidBatch</exceptionCode>\n" +
+                "<exceptionMessage>Records not processed</exceptionMessage>\n" +
+                "</error>").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.XML);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowCsv() {
+        InputStream inputStream = new ByteArrayInputStream(("<error xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n" +
+                "<exceptionCode>InvalidBatch</exceptionCode>\n" +
+                "<exceptionMessage>Records not processed</exceptionMessage>\n" +
+                "</error>").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.CSV);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowJson() {
+        InputStream inputStream = new ByteArrayInputStream(("{" +
+                "\"exceptionCode\":\"InvalidBatch\"," +
+                "\"exceptionMessage\":\"Records not processed\"" +
+                "}").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.JSON);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowZipXml() {
+        InputStream inputStream = new ByteArrayInputStream(("<error xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n" +
+                "<exceptionCode>InvalidBatch</exceptionCode>\n" +
+                "<exceptionMessage>Records not processed</exceptionMessage>\n" +
+                "</error>").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.ZIP_XML);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowZipCsv() {
+        InputStream inputStream = new ByteArrayInputStream(("<error xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n" +
+                "<exceptionCode>InvalidBatch</exceptionCode>\n" +
+                "<exceptionMessage>Records not processed</exceptionMessage>\n" +
+                "</error>").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.ZIP_CSV);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowZipJson() {
+        InputStream inputStream = new ByteArrayInputStream(("{" +
+                "\"exceptionCode\":\"InvalidBatch\"," +
+                "\"exceptionMessage\":\"Records not processed\"" +
+                "}").getBytes());
+        try {
+            BulkConnection.parseAndThrowException(inputStream, ContentType.ZIP_JSON);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals("Records not processed", aae.getExceptionMessage());
+            Assert.assertEquals(AsyncExceptionCode.InvalidBatch, aae.getExceptionCode());
+        }
+    }
+
+    @Test
+    public void testParseAndThrowNull() {
+        try {
+            BulkConnection.parseAndThrowException(new ByteArrayInputStream(new byte[0]), null);
+        } catch (AsyncApiException aae) {
+            Assert.assertEquals(AsyncExceptionCode.ClientInputError, aae.getExceptionCode());
+        }
+    }
+}


### PR DESCRIPTION
There were gaps in the JSON support for Bulk API, specifically around parsing errors coming back from the server. This change parameterizes the error parsing code with a content type. For XML and CSV jobs, the errors will be in XML. For JSON jobs, the errors will be in JSON.