### PR TITLE
Modify copyright statement to match copyright template required by maven-license-plugin

### DIFF
--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, salesforce.com, inc.
+ * Copyright (c) 2013, salesforce.com, inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided

--- a/src/test/java/com/sforce/async/BulkConnectionTest.java
+++ b/src/test/java/com/sforce/async/BulkConnectionTest.java
@@ -1,8 +1,29 @@
 /*
- * Copyright, 2015, salesforce.com
- * All Rights Reserved
- * Company Confidential
+ * Copyright (c) 2013, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
+
 package com.sforce.async;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
The attached PR solves Issue #125.  However, the proper solution is to update the maven-license-plugin license.txt file to reflect a revised copyright notice.  This will require all module copyright notices to be revised to match the contents of the license.txt file to avoid the issue this PR temporarily resolves.