### PR TITLE
Add ExtendedErrorDetails custom template for supporting <any/> tag

### DIFF
--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -28,6 +28,7 @@ package com.sforce.ws.bind;
 
 import com.sforce.ws.ConnectionException;
 import com.sforce.ws.ConnectorConfig;
+import com.sforce.ws.codegen.Generator;
 import com.sforce.ws.parser.XmlInputStream;
 import com.sforce.ws.parser.XmlOutputStream;
 import com.sforce.ws.types.Time;
@@ -39,6 +40,7 @@ import com.sforce.ws.wsdl.SimpleType;
 import com.sforce.ws.wsdl.Types;
 
 import javax.xml.namespace.QName;
+
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -191,6 +193,11 @@ public class TypeMapper {
         		(SfdcApiType.Enterprise.getSobjectNamespace().equals(namespace) ||
         		 SfdcApiType.Tooling.getSobjectNamespace().equals(namespace))) {
             return true;
+        }
+         
+        if (Generator.EXTENDED_ERROR_DETAILS.equalsIgnoreCase(name)) {
+        	//We use a custom template to generate source for it.
+        	return true;
         }
 
         QName type = new QName(namespace, name);

--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -70,6 +70,7 @@ public class TypeMapper {
 
     // True if interfaces are generated for the WSDL
     private boolean generateInterfaces;
+    private boolean generateExtendedErrorCodes;
 
     private static HashMap<String, QName> getJavaXmlMapping() {
         HashMap<String, QName> map = new HashMap<String, QName>();
@@ -197,6 +198,7 @@ public class TypeMapper {
          
         if (Generator.EXTENDED_ERROR_DETAILS.equalsIgnoreCase(name)) {
         	//We use a custom template to generate source for it.
+        	setGenerateExtendedErrorCodes(true);
         	return true;
         }
 
@@ -803,6 +805,14 @@ public class TypeMapper {
 
     public boolean generateInterfaces() {
         return generateInterfaces;
+    }
+    
+    public void setGenerateExtendedErrorCodes(boolean generateExtendedErrorCodes) {
+    	this.generateExtendedErrorCodes = generateExtendedErrorCodes;
+    }
+    
+    public boolean getGenerateExtendedErrorCodes() {
+    	return generateExtendedErrorCodes;
     }
 
     public static class PartialArrayException extends ConnectionException {

--- a/src/main/java/com/sforce/ws/codegen/Generator.java
+++ b/src/main/java/com/sforce/ws/codegen/Generator.java
@@ -52,6 +52,7 @@ abstract public class Generator {
     private static final int BUFFER_SIZE_16_KIB = 16 * 1024;
 
     private static final String AGGREGATE_RESULT_JAVA = "AggregateResult.java";
+    private static final String EXTENDED_ERROR_DETAILS_JAVA = "ExtendedErrorDetails.java";
     private static final String SOBJECT_JAVA = "SObject.java";
     private static final String ISOBJECT_JAVA = "ISObject.java";
 
@@ -62,6 +63,7 @@ abstract public class Generator {
     public final static String SIMPLE_TYPE = "simpleType";
     public final static String SOBJECT = "sobject";
     public final static String ISOBJECT = "isobject";
+    public final static String EXTENDED_ERROR_DETAILS = "extendedErrorDetails";
 
     public final static String TYPE = "type";
     public final static String TYPE_INTERFACE = "typeinterface";
@@ -150,6 +152,7 @@ abstract public class Generator {
             if (requiresAggregateResultClass(definitions)) {
                 generateAggregateResultClasses(definitions, dir);
             }
+            generateExtendedErrorDetailsClasses(definitions, dir);
         }
     }
 
@@ -183,7 +186,14 @@ abstract public class Generator {
         ST template = templates.getInstanceOf(AGGREGATE_RESULT);
         javaFiles.add(generate(packageName, AGGREGATE_RESULT_JAVA, gen, template, dir));
     }
-
+    
+    protected void generateExtendedErrorDetailsClasses(Definitions definitions, File dir) throws IOException {
+    	String packageName = NameMapper.getPackageName(definitions.getApiType().getNamespace(), packagePrefix);
+    	ClassMetadata gen = new ClassMetadata(packageName, null);
+        ST template = templates.getInstanceOf(EXTENDED_ERROR_DETAILS);
+        javaFiles.add(generate(packageName, EXTENDED_ERROR_DETAILS_JAVA, gen, template, dir));
+    }
+    
     protected void generateClassFromComplexType(Types types, Schema schema, ComplexType complexType, File dir)
             throws IOException {
         ComplexClassMetadata gen = newTypeMetadataConstructor(types, schema, complexType, dir)

--- a/src/main/java/com/sforce/ws/codegen/Generator.java
+++ b/src/main/java/com/sforce/ws/codegen/Generator.java
@@ -75,6 +75,7 @@ abstract public class Generator {
 
     protected final STGroupDir templates;
     protected boolean generateInterfaces;
+    private boolean generateExtendedErrorDetails;
 
 
     public Generator(String packagePrefix, STGroupDir templates, String interfacePackagePrefix) throws Exception {
@@ -152,7 +153,9 @@ abstract public class Generator {
             if (requiresAggregateResultClass(definitions)) {
                 generateAggregateResultClasses(definitions, dir);
             }
-            generateExtendedErrorDetailsClasses(definitions, dir);
+            if (typeMapper.getGenerateExtendedErrorCodes()) {
+            	generateExtendedErrorDetailsClasses(definitions, dir);
+            }
         }
     }
 

--- a/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
@@ -43,8 +43,6 @@ import java.io.IOException;
  */
 public class ExtendedErrorDetails extends XmlObject {
 
-    private XmlObject xmlObject = new XmlObject();
-
     public ExtendedErrorDetails() {
     }
 
@@ -52,22 +50,13 @@ public class ExtendedErrorDetails extends XmlObject {
 	 * @return the details associated with the field. You can find the fields to expect for 
 	 * the given {@link #getExtendedErrorCode()} in the wsdl, or online documentation. 
 	 */
+	@Override
     public Object getField(String name) {
-        return xmlObject.getField(name);
+        return super.getField(name);
     }
 
     public String getExtendedErrorCode() {
-        return (String)xmlObject.getField("extendedErrorCode");
-    }
-
-    @Override
-    public void write(QName element, XmlOutputStream out, TypeMapper typeMapper) throws IOException {
-        xmlObject.write(element, out, typeMapper);
-    }
-
-	@Override
-    public void load(XmlInputStream in, TypeMapper typeMapper) throws IOException, ConnectionException {
-        xmlObject.load(in, typeMapper);
+        return (String)getField("extendedErrorCode");
     }
 }
 

--- a/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
@@ -1,5 +1,6 @@
+extendedErrorDetails(gen) ::= <<
 /*
- * Copyright (c) 2013, salesforce.com, inc.
+ * Copyright (c) 2005-2016 salesforce.com, inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided
@@ -23,35 +24,51 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+package $gen.packageName$;
 
-package com.sforce.ws.codegen;
+import com.sforce.ws.bind.XmlObject;
+import com.sforce.ws.bind.TypeMapper;
+import com.sforce.ws.wsdl.Constants;
+import com.sforce.ws.parser.XmlInputStream;
+import com.sforce.ws.parser.XmlOutputStream;
+import com.sforce.ws.ConnectionException;
 
-import junit.framework.TestCase;
+import javax.xml.namespace.QName;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.io.IOException;
 
-import org.stringtemplate.v4.ST;
-import org.stringtemplate.v4.STGroupDir;
+/**
+ * ExtendedErrorDetails is loosely typed. You can use {@link #getField(String)} to get the information 
+ */
+public class ExtendedErrorDetails extends XmlObject {
 
-import com.sforce.ws.codegen.metadata.ClassMetadata;
-import com.sforce.ws.tools.wsdlc;
+    private XmlObject xmlObject = new XmlObject();
 
-public class AggregateCodeGeneratorTest extends TestCase {
-
-    public void testGenerateSObjectSource() throws Exception {
-        String expectedSource = CodeGeneratorTestUtil.fileToString("AggregateResult.java");
-        STGroupDir templates = new STGroupDir(wsdlc.TEMPLATE_DIR, '$', '$');
-        ST template = templates.getInstanceOf(Generator.AGGREGATE_RESULT);
-        assertNotNull(template);
-        template.add("gen", new ClassMetadata("com.sforce.soap.enterprise.sobject", null));
-        assertEquals(expectedSource, template.render());
+    public ExtendedErrorDetails() {
     }
-    
-    public void testGenerateExtendedSource() throws Exception {
-        String expectedSource = CodeGeneratorTestUtil.fileToString("ExtendedErrorDetails.java");
-        STGroupDir templates = new STGroupDir(wsdlc.TEMPLATE_DIR, '$', '$');
-        ST template = templates.getInstanceOf(Generator.EXTENDED_ERROR_DETAILS);
-        assertNotNull(template);
-        template.add("gen", new ClassMetadata("com.sforce.soap.enterprise", null));
-        assertEquals(expectedSource, template.render());
+
+	/**
+	 * @return the details associated with the field. You can find the fields to expect for 
+	 * the given {@link #getExtendedErrorCode()} in the wsdl, or online documentation. 
+	 */
+    public Object getField(String name) {
+        return xmlObject.getField(name);
     }
-    
+
+    public String getExtendedErrorCode() {
+        return (String)xmlObject.getField("extendedErrorCode");
+    }
+
+    @Override
+    public void write(QName element, XmlOutputStream out, TypeMapper typeMapper) throws IOException {
+        xmlObject.write(element, out, typeMapper);
+    }
+
+	@Override
+    public void load(XmlInputStream in, TypeMapper typeMapper) throws IOException, ConnectionException {
+        xmlObject.load(in, typeMapper);
+    }
 }
+
+>>

--- a/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/extendedErrorDetails.st
@@ -27,24 +27,12 @@ extendedErrorDetails(gen) ::= <<
 package $gen.packageName$;
 
 import com.sforce.ws.bind.XmlObject;
-import com.sforce.ws.bind.TypeMapper;
-import com.sforce.ws.wsdl.Constants;
-import com.sforce.ws.parser.XmlInputStream;
-import com.sforce.ws.parser.XmlOutputStream;
-import com.sforce.ws.ConnectionException;
-
-import javax.xml.namespace.QName;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.io.IOException;
+import $gen.packageName$.ExtendedErrorCode;
 
 /**
  * ExtendedErrorDetails is loosely typed. You can use {@link #getField(String)} to get the information 
  */
 public class ExtendedErrorDetails extends XmlObject {
-
-    public ExtendedErrorDetails() {
-    }
 
 	/**
 	 * @return the details associated with the field. You can find the fields to expect for 
@@ -55,8 +43,12 @@ public class ExtendedErrorDetails extends XmlObject {
         return super.getField(name);
     }
 
-    public String getExtendedErrorCode() {
-        return (String)getField("extendedErrorCode");
+    public ExtendedErrorCode getExtendedErrorCode() {
+    	String extendedErrorCode = (String)getField("extendedErrorCode");
+    	if (extendedErrorCode != null) {
+    		return ExtendedErrorCode.valueOf(extendedErrorCode);
+    	}
+        return null;
     }
 }
 

--- a/src/test/resources/codegeneration/ExtendedErrorDetails.java
+++ b/src/test/resources/codegeneration/ExtendedErrorDetails.java
@@ -42,8 +42,6 @@ import java.io.IOException;
  */
 public class ExtendedErrorDetails extends XmlObject {
 
-    private XmlObject xmlObject = new XmlObject();
-
     public ExtendedErrorDetails() {
     }
 
@@ -51,21 +49,12 @@ public class ExtendedErrorDetails extends XmlObject {
 	 * @return the details associated with the field. You can find the fields to expect for 
 	 * the given {@link #getExtendedErrorCode()} in the wsdl, or online documentation. 
 	 */
+	@Override
     public Object getField(String name) {
-        return xmlObject.getField(name);
+        return super.getField(name);
     }
 
     public String getExtendedErrorCode() {
-        return (String)xmlObject.getField("extendedErrorCode");
-    }
-
-    @Override
-    public void write(QName element, XmlOutputStream out, TypeMapper typeMapper) throws IOException {
-        xmlObject.write(element, out, typeMapper);
-    }
-
-	@Override
-    public void load(XmlInputStream in, TypeMapper typeMapper) throws IOException, ConnectionException {
-        xmlObject.load(in, typeMapper);
+        return (String)getField("extendedErrorCode");
     }
 }

--- a/src/test/resources/codegeneration/ExtendedErrorDetails.java
+++ b/src/test/resources/codegeneration/ExtendedErrorDetails.java
@@ -26,24 +26,12 @@
 package com.sforce.soap.enterprise;
 
 import com.sforce.ws.bind.XmlObject;
-import com.sforce.ws.bind.TypeMapper;
-import com.sforce.ws.wsdl.Constants;
-import com.sforce.ws.parser.XmlInputStream;
-import com.sforce.ws.parser.XmlOutputStream;
-import com.sforce.ws.ConnectionException;
-
-import javax.xml.namespace.QName;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.io.IOException;
+import com.sforce.soap.enterprise.ExtendedErrorCode;
 
 /**
  * ExtendedErrorDetails is loosely typed. You can use {@link #getField(String)} to get the information 
  */
 public class ExtendedErrorDetails extends XmlObject {
-
-    public ExtendedErrorDetails() {
-    }
 
 	/**
 	 * @return the details associated with the field. You can find the fields to expect for 
@@ -54,7 +42,11 @@ public class ExtendedErrorDetails extends XmlObject {
         return super.getField(name);
     }
 
-    public String getExtendedErrorCode() {
-        return (String)getField("extendedErrorCode");
+    public ExtendedErrorCode getExtendedErrorCode() {
+    	String extendedErrorCode = (String)getField("extendedErrorCode");
+    	if (extendedErrorCode != null) {
+    		return ExtendedErrorCode.valueOf(extendedErrorCode);
+    	}
+        return null;
     }
 }

--- a/src/test/resources/codegeneration/ExtendedErrorDetails.java
+++ b/src/test/resources/codegeneration/ExtendedErrorDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, salesforce.com, inc.
+ * Copyright (c) 2005-2016 salesforce.com, inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided
@@ -23,35 +23,49 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+package com.sforce.soap.enterprise;
 
-package com.sforce.ws.codegen;
+import com.sforce.ws.bind.XmlObject;
+import com.sforce.ws.bind.TypeMapper;
+import com.sforce.ws.wsdl.Constants;
+import com.sforce.ws.parser.XmlInputStream;
+import com.sforce.ws.parser.XmlOutputStream;
+import com.sforce.ws.ConnectionException;
 
-import junit.framework.TestCase;
+import javax.xml.namespace.QName;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.io.IOException;
 
-import org.stringtemplate.v4.ST;
-import org.stringtemplate.v4.STGroupDir;
+/**
+ * ExtendedErrorDetails is loosely typed. You can use {@link #getField(String)} to get the information 
+ */
+public class ExtendedErrorDetails extends XmlObject {
 
-import com.sforce.ws.codegen.metadata.ClassMetadata;
-import com.sforce.ws.tools.wsdlc;
+    private XmlObject xmlObject = new XmlObject();
 
-public class AggregateCodeGeneratorTest extends TestCase {
-
-    public void testGenerateSObjectSource() throws Exception {
-        String expectedSource = CodeGeneratorTestUtil.fileToString("AggregateResult.java");
-        STGroupDir templates = new STGroupDir(wsdlc.TEMPLATE_DIR, '$', '$');
-        ST template = templates.getInstanceOf(Generator.AGGREGATE_RESULT);
-        assertNotNull(template);
-        template.add("gen", new ClassMetadata("com.sforce.soap.enterprise.sobject", null));
-        assertEquals(expectedSource, template.render());
+    public ExtendedErrorDetails() {
     }
-    
-    public void testGenerateExtendedSource() throws Exception {
-        String expectedSource = CodeGeneratorTestUtil.fileToString("ExtendedErrorDetails.java");
-        STGroupDir templates = new STGroupDir(wsdlc.TEMPLATE_DIR, '$', '$');
-        ST template = templates.getInstanceOf(Generator.EXTENDED_ERROR_DETAILS);
-        assertNotNull(template);
-        template.add("gen", new ClassMetadata("com.sforce.soap.enterprise", null));
-        assertEquals(expectedSource, template.render());
+
+	/**
+	 * @return the details associated with the field. You can find the fields to expect for 
+	 * the given {@link #getExtendedErrorCode()} in the wsdl, or online documentation. 
+	 */
+    public Object getField(String name) {
+        return xmlObject.getField(name);
     }
-    
+
+    public String getExtendedErrorCode() {
+        return (String)xmlObject.getField("extendedErrorCode");
+    }
+
+    @Override
+    public void write(QName element, XmlOutputStream out, TypeMapper typeMapper) throws IOException {
+        xmlObject.write(element, out, typeMapper);
+    }
+
+	@Override
+    public void load(XmlInputStream in, TypeMapper typeMapper) throws IOException, ConnectionException {
+        xmlObject.load(in, typeMapper);
+    }
 }


### PR DESCRIPTION
Adding a custom template for supporting <any/> on the loosely typed ExtendedErrorDetails section of the wsdl