### PR TITLE
force-wsc v37.0 seems to balk on ExtendedErrorDetails when generating WSDLs from 202/patch

### DIFF
--- a/src/main/java/com/sforce/ws/codegen/Generator.java
+++ b/src/main/java/com/sforce/ws/codegen/Generator.java
@@ -75,8 +75,6 @@ abstract public class Generator {
 
     protected final STGroupDir templates;
     protected boolean generateInterfaces;
-    private boolean generateExtendedErrorDetails;
-
 
     public Generator(String packagePrefix, STGroupDir templates, String interfacePackagePrefix) throws Exception {
         this(packagePrefix, templates, interfacePackagePrefix, '$', '$');
@@ -153,9 +151,9 @@ abstract public class Generator {
             if (requiresAggregateResultClass(definitions)) {
                 generateAggregateResultClasses(definitions, dir);
             }
-            if (typeMapper.getGenerateExtendedErrorCodes()) {
-            	generateExtendedErrorDetailsClasses(definitions, dir);
-            }
+        }
+        if (typeMapper.getGenerateExtendedErrorCodes()) {
+        	generateExtendedErrorDetailsClasses(definitions, dir);
         }
     }
 


### PR DESCRIPTION
ExtendedErrorDetails weren't getting generated for non-sObject wsdl which wasn't the right thing to do.
https://gus.my.salesforce.com/a07B000000231ASIAY