### PR TITLE
Additional changes to make ExtendedErrorDetails work with wsc

### DIFF
--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -196,8 +196,8 @@ public class TypeMapper {
             return true;
         }
          
-        if (Generator.EXTENDED_ERROR_DETAILS.equalsIgnoreCase(name)) {
-        	//We use a custom template to generate source for it.
+        if (Generator.EXTENDED_ERROR_DETAILS.equalsIgnoreCase(name) && SfdcApiType.getFromNamespace(namespace) != null) {
+        	//We use a custom template to generate source for it for known SfdcApiTypes. For the rest, generate the default classes which won't be able to use getField(...)
         	setGenerateExtendedErrorCodes(true);
         	return true;
         }

--- a/src/main/java/com/sforce/ws/codegen/Generator.java
+++ b/src/main/java/com/sforce/ws/codegen/Generator.java
@@ -53,6 +53,7 @@ abstract public class Generator {
 
     private static final String AGGREGATE_RESULT_JAVA = "AggregateResult.java";
     private static final String EXTENDED_ERROR_DETAILS_JAVA = "ExtendedErrorDetails.java";
+    private static final String IEXTENDED_ERROR_DETAILS_JAVA = "IExtendedErrorDetails.java";
     private static final String SOBJECT_JAVA = "SObject.java";
     private static final String ISOBJECT_JAVA = "ISObject.java";
 
@@ -64,6 +65,7 @@ abstract public class Generator {
     public final static String SOBJECT = "sobject";
     public final static String ISOBJECT = "isobject";
     public final static String EXTENDED_ERROR_DETAILS = "extendedErrorDetails";
+    public final static String IEXTENDED_ERROR_DETAILS = "iExtendedErrorDetails";
 
     public final static String TYPE = "type";
     public final static String TYPE_INTERFACE = "typeinterface";
@@ -193,6 +195,10 @@ abstract public class Generator {
     	ClassMetadata gen = new ClassMetadata(packageName, null);
         ST template = templates.getInstanceOf(EXTENDED_ERROR_DETAILS);
         javaFiles.add(generate(packageName, EXTENDED_ERROR_DETAILS_JAVA, gen, template, dir));
+        if (generateInterfaces) {
+            ST interfc = templates.getInstanceOf(IEXTENDED_ERROR_DETAILS);
+            javaFiles.add(generate(packageName, IEXTENDED_ERROR_DETAILS_JAVA, gen, interfc, dir));
+        }
     }
     
     protected void generateClassFromComplexType(Types types, Schema schema, ComplexType complexType, File dir)

--- a/src/main/java/com/sforce/ws/codegen/templates/iExtendedErrorDetails.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/iExtendedErrorDetails.st
@@ -1,4 +1,4 @@
-extendedErrorDetails(gen) ::= <<
+iExtendedErrorDetails(gen) ::= <<
 /*
  * Copyright (c) 2005-2016 salesforce.com, inc.
  * All rights reserved.
@@ -32,24 +32,15 @@ import $gen.packageName$.ExtendedErrorCode;
 /**
  * ExtendedErrorDetails is loosely typed. You can use {@link #getField(String)} to get the information 
  */
-public class ExtendedErrorDetails extends XmlObject implements IExtendedErrorDetails {
+public interface IExtendedErrorDetails {
 
 	/**
 	 * @return the details associated with the field. You can find the fields to expect for 
 	 * the given {@link #getExtendedErrorCode()} in the wsdl, or online documentation. 
 	 */
-	@Override
-    public Object getField(String name) {
-        return super.getField(name);
-    }
+    public Object getField(String name);
 
-    public ExtendedErrorCode getExtendedErrorCode() {
-    	String extendedErrorCode = (String)getField("extendedErrorCode");
-    	if (extendedErrorCode != null) {
-    		return ExtendedErrorCode.valueOf(extendedErrorCode);
-    	}
-        return null;
-    }
+    public ExtendedErrorCode getExtendedErrorCode();
 }
 
 >>


### PR DESCRIPTION
ExtendedErrorDetails needed an interface to work with partner API.
if an unknown SfdcApiType wsdl is used with wsc, we won't generate the special classes for ExtendedErrorDetails, we generate the usual classes which doesn't have getField(..) capability for xsd:any. It can just use getExtendedErrorCode.