### PR TITLE
Add statusCode and header accessors to Transport.

### DIFF
--- a/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
+++ b/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
@@ -52,6 +52,8 @@ public class JdkHttpTransport implements Transport {
     private boolean successful;
     private ConnectorConfig config;
     private URL url;
+    private int statusCode;
+    private Map<String, Collection<String>> headers;
 
     public JdkHttpTransport() {
     }
@@ -209,7 +211,13 @@ public class JdkHttpTransport implements Transport {
             }
         }
 
-        successful = connection.getResponseCode() < 400;
+        statusCode = connection.getResponseCode();
+        successful = statusCode < 400;
+        
+        headers = new HashMap<String, Collection<String>>();
+        for (Entry<String, List<String>> entry : connection.getHeaderFields().entrySet()) {
+            headers.put(entry.getKey(), entry.getValue());
+        }
 
         String encoding = connection.getHeaderField("Content-Encoding");
 
@@ -255,6 +263,16 @@ public class JdkHttpTransport implements Transport {
     @Override
     public boolean isSuccessful() {
         return successful;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public Map<String, Collection<String>> getHeaders() {
+        return headers;
     }
 
 }

--- a/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
+++ b/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
@@ -214,10 +214,7 @@ public class JdkHttpTransport implements Transport {
         statusCode = connection.getResponseCode();
         successful = statusCode < 400;
         
-        headers = new HashMap<String, Collection<String>>();
-        for (Entry<String, List<String>> entry : connection.getHeaderFields().entrySet()) {
-            headers.put(entry.getKey(), entry.getValue());
-        }
+        headers = new HashMap<String, Collection<String>>(connection.getHeaderFields());
 
         String encoding = connection.getHeaderField("Content-Encoding");
 

--- a/src/main/java/com/sforce/ws/transport/Transport.java
+++ b/src/main/java/com/sforce/ws/transport/Transport.java
@@ -26,12 +26,10 @@
 
 package com.sforce.ws.transport;
 
-import com.sforce.ws.ConnectorConfig;
+import java.io.*;
+import java.util.*;
 
-import java.io.OutputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.util.HashMap;
+import com.sforce.ws.ConnectorConfig;
 
 /**
  * This interface defines a Transport.
@@ -65,9 +63,24 @@ public interface Transport {
 
     /**
      * checks whether the response from the remote server is successful or not.
+     * This method must be called after getContent.
      * @return true if the call was successful
      */
     boolean isSuccessful();
+    
+    /**
+     * returns the status code received from the endpoint. This method must be
+     * called after getContent.
+     * @return the HTTP status code
+     */
+    int getStatusCode();
+    
+    /**
+     * return the response headers received from the endpoint. This method
+     * must be called after getContent.
+     * @return
+     */
+    Map<String, Collection<String>> getHeaders(); 
 
     OutputStream connect(String endpoint, HashMap<String, String> headers) throws IOException;
 


### PR DESCRIPTION
Needed for connections that want to use Transport and want access to statusCode (instead of just isSuccessful) and the response headers.