### PR TITLE
Fixes the occational NullPointerException

### DIFF
--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -736,10 +736,13 @@ public class BulkConnection {
 
         if (!success) {
             ContentType type = null;
-            if (connection.getContentType().contains(XML_CONTENT_TYPE)) {
-                type = ContentType.XML;
-            } else if (connection.getContentType().contains(JSON_CONTENT_TYPE)) {
-                type = ContentType.JSON;
+            String contentTypeHeader = connection.getContentType();
+            if (contentTypeHeader != null) {
+                if (contentTypeHeader.contains(XML_CONTENT_TYPE)) {
+                    type = ContentType.XML;
+                } else if (contentTypeHeader.contains(JSON_CONTENT_TYPE)) {
+                    type = ContentType.JSON;
+                }
             }
             parseAndThrowException(in, type);
         }


### PR DESCRIPTION
Related issue: forcedotcom/wsc#161

The exception is thrown when the response for an HTTP GET does not include XML or JSON content type. No tests added. Existing tests passing on my local environment.
