### PR TITLE
Increase maximum size of CSV cell to 131072

### DIFF
--- a/src/main/java/com/sforce/async/CSVReader.java
+++ b/src/main/java/com/sforce/async/CSVReader.java
@@ -47,7 +47,7 @@ public class CSVReader {
     private StreamTokenizer parser;
     private char[] separators;
     private boolean ignoreBlankRecords = true;
-    private int maxSizeOfIndividualCell = 32000;
+    private int maxSizeOfIndividualCell = 131072;
     private int maxColumnsPerRow = 5000;
     private int maxRowSizeInCharacters = 400000; //400K of characters in a row..
 


### PR DESCRIPTION
To support long text and rich text fields.

Fixes #182.