### PR TITLE
Add ability to set SSLContext on ConnectorConfig

### DIFF
--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 import javax.xml.namespace.QName;
 
 import com.sforce.ws.ConnectionException;
@@ -679,6 +681,10 @@ public class BulkConnection {
 
     private InputStream doHttpGet(URL url) throws IOException, AsyncApiException {
         HttpURLConnection connection = config.createConnection(url, null);
+        SSLContext sslContext = config.getSslContext();
+        if (sslContext != null && connection instanceof HttpsURLConnection) {
+            ((HttpsURLConnection)connection).setSSLSocketFactory(sslContext.getSocketFactory());
+        }
         connection.setRequestProperty(SESSION_ID, config.getSessionId());
 
         boolean success = true;

--- a/src/main/java/com/sforce/ws/ConnectorConfig.java
+++ b/src/main/java/com/sforce/ws/ConnectorConfig.java
@@ -37,6 +37,8 @@ import com.sforce.ws.transport.TransportFactory;
 import com.sforce.ws.util.Base64;
 import com.sforce.ws.util.Verbose;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * This class contains a set of configuration properties
  * 
@@ -154,8 +156,17 @@ public class ConnectorConfig {
     private SessionRenewer sessionRenewer;
     private String ntlmDomain;
 	private TransportFactory transportFactory;
+	  private SSLContext sslContext;
 
     public static final ConnectorConfig DEFAULT = new ConnectorConfig();
+
+    public void setSslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    public SSLContext getSslContext() {
+        return sslContext;
+    }
 
     public Class getTransport() {
         return transport;

--- a/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
+++ b/src/main/java/com/sforce/ws/transport/JdkHttpTransport.java
@@ -39,6 +39,9 @@ import com.sforce.ws.tools.VersionInfo;
 import com.sforce.ws.util.Base64;
 import com.sforce.ws.util.FileUtil;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+
 /**
  * This class is an implementation of Transport using the build in
  * JDK URLConnection.
@@ -126,6 +129,10 @@ public class JdkHttpTransport implements Transport {
         url = new URL(uri);
 
         connection = createConnection(config, url, httpHeaders, enableCompression);
+        SSLContext sslContext = config.getSslContext();
+        if (sslContext != null && connection instanceof HttpsURLConnection) {
+            ((HttpsURLConnection)connection).setSSLSocketFactory(sslContext.getSocketFactory());
+        }
         connection.setRequestMethod("POST");
         connection.setDoInput(true);
         connection.setDoOutput(true);


### PR DESCRIPTION
Add ability to set SSLContext on ConnectorConfig, use the custom SSLContext (if present) when creating connections in SOAP and Bulk APIs. Fixes #213.