### PR TITLE
Updating the code to be able to handle sizes > 2 Gigs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.force.api</groupId>
   <artifactId>force-wsc</artifactId>
   <packaging>jar</packaging>
-  <version>42.0.0</version>
+  <version>42.0.1</version>
   <name>force-wsc</name>
   <description>Force.com Web Service Connector</description>
   <url>http://www.force.com</url>

--- a/src/main/java/com/sforce/ws/transport/LimitingOutputStream.java
+++ b/src/main/java/com/sforce/ws/transport/LimitingOutputStream.java
@@ -30,36 +30,61 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class LimitingOutputStream extends OutputStream {
-    private int size = 0;
+	@Deprecated
+	private int size = 0;
+	private long sizeLong = 0L;
+    @Deprecated
     private int maxSize;
+    private long maxSizeLong;
     private OutputStream out;
+    private static final String MAX_SIZE_EXCEEDED_ERROR =  "Exceeded max size limit of %d%n with request size %d%n";
 
+    /**
+     * Please use {@link com.sforce.ws.transport.LimitingOutputStream#LimitingOutputStream(long, OutputStream) instead.
+     */
+    @Deprecated
     public LimitingOutputStream(int maxSize, OutputStream out) {
         this.maxSize = maxSize;
+        this.maxSizeLong = maxSize;
         this.out = out;
     }
+    
+    public LimitingOutputStream(long maxSize, OutputStream out) {
+        this.maxSizeLong = maxSize;
+        this.out = out;
+    } 
 
+    /**
+     * Please use @see {@link com.sforce.ws.transport.LimitingOutputStream#getSizeLong() instead.
+     */
+    @Deprecated
     public int getSize() {
         return size;
+    }
+    
+    public long getSizeLong() {
+        return sizeLong;
     }
 
     @Override
     public void write(int b) throws IOException {
         size++;
+        sizeLong++;
         checkSizeLimit();
         out.write(b);
     }
 
     private void checkSizeLimit() throws IOException {
-        if (size > maxSize) {
-            throw new IOException("Exceeded max size limit of " +
-                    maxSize + " with request size " + size);
-        }
+    	if (sizeLong > maxSizeLong) {
+            throw new IOException(String.format(MAX_SIZE_EXCEEDED_ERROR, maxSizeLong, sizeLong));
+    	}
     }
 
     @Override
     public void write(byte b[]) throws IOException {
-        size += b.length;
+    	int length = b.length;
+        size += length;
+        sizeLong += length;
         checkSizeLimit();
         out.write(b);
     }
@@ -67,6 +92,7 @@ public class LimitingOutputStream extends OutputStream {
     @Override
     public void write(byte b[], int off, int len) throws IOException {
         size += len;
+        sizeLong += len;
         checkSizeLimit();
         out.write(b, off, len);
     }


### PR DESCRIPTION
LimitingOutputStream.java uses 'int' when dealing with sizes which causes issues when size is greater then Integer.MAX_VALUE. So deprecating methods and variables which leverage 'int' and adding methods to handle larger sizes using 'long'.