### PR TITLE
Fix for OS-independent generation of batches from directories.

### DIFF
--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -255,7 +255,7 @@ public class BulkConnection {
             throws AsyncApiException {
         final List<File> files = FileUtil.listFilesRecursive(attachmentDir, false);
         final Map<String, File> fileMap = new HashMap<String, File>(files.size());
-        final String rootPath = attachmentDir.getAbsolutePath() + "/";
+        final String rootPath = attachmentDir.getAbsolutePath() + File.separator;
         for (File f : files) {
             String name = f.getAbsolutePath().replace(rootPath, "");
             fileMap.put(name, f);


### PR DESCRIPTION
Came across this when code would run on OS X but not on Windows. Without this, on windows, the files that are pushed to Salesforce as the batch request contain the full path as well as the filename, and the API throws an error that it cannot locate a file that is mentioned in request.txt.