### PR TITLE
Update AsyncExceptionCode for Transaction Security

### DIFF
--- a/src/main/java/com/sforce/async/AsyncExceptionCode.java
+++ b/src/main/java/com/sforce/async/AsyncExceptionCode.java
@@ -52,5 +52,8 @@ public enum AsyncExceptionCode {
     InvalidVersion,
     HttpsRequired,
     UnsupportedContentType,
-    InvalidEntity
+    InvalidEntity,
+    TransactionSecurityBlock,
+    TransactionSecurityInternalError,
+    TransactionSecurityDeveloperError
 }


### PR DESCRIPTION
When TransactionSecurityPolicies execute and take a block action during bulk api, the action is still taken but the action is mapped to an unknown exception. So adding a TransactionSecurityBlock code for those cases.

TransactionSecurityInternalError is used when policy execution hit some kind of internal salesforce developer error like NullPointerException.

TransactionSecurityDeveloperError is used when customer policies hit a customer developer exception, like customer apex policy hits a NullPointerException.