### PR TITLE
fix non-working java-time feature #235 and update test

### DIFF
--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -155,9 +155,7 @@ public class TypeMapper {
     private final Map<String, QName> javaXmlMapping;
 
     public TypeMapper() {
-        boolean javaTime = false;
-        this.xmlJavaMapping = getXmlJavaMapping(javaTime);
-        this.javaXmlMapping = getJavaXmlMapping(javaTime);
+	this(null, null, false);
     }
 
     public TypeMapper(String packagePrefix, String interfacePackagePrefix, boolean javaTime) {

--- a/src/main/java/com/sforce/ws/bind/TypeMapper.java
+++ b/src/main/java/com/sforce/ws/bind/TypeMapper.java
@@ -63,8 +63,6 @@ import java.util.*;
 public class TypeMapper {
     public static final String HTML = "html";
     private static HashMap<QName, String> nillableJavaMapping = getNillableXmlJavaMapping();
-    private final HashMap<QName, String> xmlJavaMapping = getXmlJavaMapping();
-    private final HashMap<String, QName> javaXmlMapping = getJavaXmlMapping();
     private static final HashSet<String> keywords = getKeyWords();
     private static HashMap<String, Class<?>> primitiveClassCache = getPrimitiveClassCache();
 
@@ -72,7 +70,7 @@ public class TypeMapper {
     private boolean generateInterfaces;
     private boolean generateExtendedErrorCodes;
 
-    private HashMap<String, QName> getJavaXmlMapping() {
+    private Map<String, QName> getJavaXmlMapping(boolean javaTime) {
         HashMap<String, QName> map = new HashMap<String, QName>();
         map.put(String.class.getName(), new QName(Constants.SCHEMA_NS, "string"));
         map.put(int.class.getName(), new QName(Constants.SCHEMA_NS, "int"));
@@ -101,7 +99,7 @@ public class TypeMapper {
         return map;
     }
 
-    private HashMap<QName, String> getXmlJavaMapping() {
+    private Map<QName, String> getXmlJavaMapping(boolean javaTime) {
         HashMap<QName, String> map = new HashMap<QName, String>();
         map.put(new QName(Constants.SCHEMA_NS, "string"), String.class.getName());
         map.put(new QName(Constants.SCHEMA_NS, "int"), int.class.getName());
@@ -151,18 +149,22 @@ public class TypeMapper {
         return map;
     }
 
-    private final boolean javaTime;
     private String packagePrefix;
     private String interfacePackagePrefix;
+    private final Map<QName, String> xmlJavaMapping;
+    private final Map<String, QName> javaXmlMapping;
 
     public TypeMapper() {
-        this.javaTime = false;
+        boolean javaTime = false;
+        this.xmlJavaMapping = getXmlJavaMapping(javaTime);
+        this.javaXmlMapping = getJavaXmlMapping(javaTime);
     }
 
     public TypeMapper(String packagePrefix, String interfacePackagePrefix, boolean javaTime) {
         this.packagePrefix = packagePrefix;
         this.interfacePackagePrefix = interfacePackagePrefix;
-        this.javaTime = javaTime;
+        this.xmlJavaMapping = getXmlJavaMapping(javaTime);
+        this.javaXmlMapping = getJavaXmlMapping(javaTime);
     }
 
     private CalendarCodec calendarCodec = new CalendarCodec();

--- a/src/test/java/com/sforce/ws/bind/TypeMapperTests.java
+++ b/src/test/java/com/sforce/ws/bind/TypeMapperTests.java
@@ -33,6 +33,7 @@ import com.sforce.ws.types.OffsetDate;
 import com.sforce.ws.wsdl.Constants;
 import org.junit.Test;
 
+import javax.xml.namespace.QName;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.*;
@@ -99,6 +100,9 @@ public class TypeMapperTests {
         TypeInfo info = new TypeInfo("", "a", Constants.SCHEMA_NS, "date", 0, 1, true);
         TypeMapper mapper = new TypeMapper(null, null, true);
 
+        String javaClassName = mapper.getJavaClassName(new QName(Constants.SCHEMA_NS, "date"), null, false);
+        assertEquals(OffsetDate.class.getName(), javaClassName);
+
         OffsetDate result1 = (OffsetDate) mapper.readObject(xmlWithoutTimeZone, info, OffsetDate.class);
         assertEquals(ZoneOffset.UTC, result1.getOffset());
         assertEquals(LocalDate.of(2019, 12, 2), result1.getDate());
@@ -121,8 +125,11 @@ public class TypeMapperTests {
         xmlWithTimeZone.setInput(new ByteArrayInputStream(withTimeZone.getBytes()), "UTF-8");
         xmlWithTimeZone.nextTag();
 
-        TypeInfo info = new TypeInfo("", "a", Constants.SCHEMA_NS, "datetime", 0, 1, true);
+        TypeInfo info = new TypeInfo("", "a", Constants.SCHEMA_NS, "dateTime", 0, 1, true);
         TypeMapper mapper = new TypeMapper(null, null, true);
+
+        String javaClassName = mapper.getJavaClassName(new QName(Constants.SCHEMA_NS, "dateTime"), null, false);
+        assertEquals(OffsetDateTime.class.getName(), javaClassName);
 
         OffsetDateTime result1 = (OffsetDateTime) mapper.readObject(xmlWithoutTimeZone, info, OffsetDateTime.class);
         assertEquals(ZoneOffset.UTC, result1.getOffset());
@@ -148,6 +155,9 @@ public class TypeMapperTests {
 
         TypeInfo info = new TypeInfo("", "a", Constants.SCHEMA_NS, "time", 0, 1, true);
         TypeMapper mapper = new TypeMapper(null, null, true);
+
+        String javaClassName = mapper.getJavaClassName(new QName(Constants.SCHEMA_NS, "time"), null, false);
+        assertEquals(OffsetTime.class.getName(), javaClassName);
 
         OffsetTime result1 = (OffsetTime) mapper.readObject(xmlWithoutTimeZone, info, OffsetTime.class);
         assertEquals(ZoneOffset.UTC, result1.getOffset());


### PR DESCRIPTION
Haven't write on Java for a while... and did this silly mistake. Initialization order does matter! javaTime field was updated **after** initialization of hash maps :-( and actual value of it was ignored (like it was always false).

And the unit test wasn't actually testing this important part... Fixed it now, updated unit test and reorganizes code to make it impossible to reappear in future.

@reubencornel could you please merge it and release fix for it? Appreciate it.

CC: @khaledez