### PR TITLE
Dependency upgrades, fixes for running under windows, jdk 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,19 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.3</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.3</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,24 @@
           <useManifestOnlyJar>false</useManifestOnlyJar>
 	</configuration>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>5.3.1</version>
+        <configuration>
+          <failBuildOnCVSS>8</failBuildOnCVSS>
+          <skipProvidedScope>true</skipProvidedScope>
+          <skipRuntimeScope>true</skipRuntimeScope>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
 	            </relocation>
                 <!-- jackson is also in core, prevent namespace collission -->
                 <relocation>
-                  <pattern>org.codehaus.jackson</pattern>
-                  <shadedPattern>com.sforce.ws.shade.org.codehaus.jackson</shadedPattern>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>com.sforce.ws.shade.com.fasterxml.jackson</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>ST4</artifactId>
-      <version>4.0.7</version>
+      <version>4.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -77,17 +77,6 @@
       <version>1.9.4</version>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <id>doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <javadoc.opts>-Xdoclint:none</javadoc.opts>
-      </properties>
-    </profile>
-  </profiles>
   <build>
     <resources>
       <resource>
@@ -112,7 +101,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -155,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -164,7 +153,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.1.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
@@ -172,7 +161,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>3.2.0</version>
         <configuration>
           <includes>
             <include>**</include>
@@ -185,8 +174,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -198,10 +188,14 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
+        <version>3.2.0</version>
         <configuration>
-          <additionalparam>${javadoc.opts}</additionalparam>
+          <source>1.8</source>
+          <target>1.8</target>
+          <doclint>none</doclint>
+          <additionalJOption>-Xdoclint:none</additionalJOption>
         </configuration>
         <executions>
           <execution>
@@ -213,10 +207,11 @@
           </execution>
         </executions>
       </plugin>
-      
-	  <plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.2</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -227,11 +222,11 @@
           </execution>
         </executions>
       </plugin>
-	  
+
       <plugin>
         <groupId>com.mycila.maven-license-plugin</groupId>
         <artifactId>maven-license-plugin</artifactId>
-        <version>1.8.0</version>
+        <version>1.10.b1</version>
         <configuration>
           <header>license.txt</header>
           <excludes>
@@ -253,7 +248,7 @@
       <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
 	<artifactId>maven-surefire-plugin</artifactId>
-	<version>2.7.1</version>
+	<version>2.22.2</version>
 	<configuration>
 	  <forkMode>always</forkMode>
           <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/src/main/java/com/sforce/async/BulkConnection.java
+++ b/src/main/java/com/sforce/async/BulkConnection.java
@@ -46,6 +46,11 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.xml.namespace.QName;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sforce.ws.ConnectionException;
 import com.sforce.ws.ConnectorConfig;
 import com.sforce.ws.MessageHandler;
@@ -57,11 +62,6 @@ import com.sforce.ws.parser.XmlInputStream;
 import com.sforce.ws.parser.XmlOutputStream;
 import com.sforce.ws.transport.Transport;
 import com.sforce.ws.util.FileUtil;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
 
 
 /**
@@ -810,7 +810,7 @@ public class BulkConnection {
      */
     static <T> T deserializeJsonToObject (InputStream in, Class<T> tmpClass) throws IOException, ConnectionException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         return mapper.readValue(in, tmpClass);
     }
 

--- a/src/main/java/com/sforce/async/Error.java
+++ b/src/main/java/com/sforce/async/Error.java
@@ -26,9 +26,9 @@
 
 package com.sforce.async;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Error --

--- a/src/main/java/com/sforce/async/JobInfo.java
+++ b/src/main/java/com/sforce/async/JobInfo.java
@@ -26,7 +26,7 @@
 
 package com.sforce.async;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Async Api JobInfo

--- a/src/test/java/com/sforce/ws/codegen/AggregateCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/AggregateCodeGeneratorTest.java
@@ -42,7 +42,9 @@ public class AggregateCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(Generator.AGGREGATE_RESULT);
         assertNotNull(template);
         template.add("gen", new ClassMetadata("com.sforce.soap.enterprise.sobject", null));
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
     
     public void testGenerateExtendedSource() throws Exception {
@@ -51,7 +53,9 @@ public class AggregateCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(Generator.EXTENDED_ERROR_DETAILS);
         assertNotNull(template);
         template.add("gen", new ClassMetadata("com.sforce.soap.enterprise", null));
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
     
 }

--- a/src/test/java/com/sforce/ws/codegen/CodeGeneratorTestUtil.java
+++ b/src/test/java/com/sforce/ws/codegen/CodeGeneratorTestUtil.java
@@ -40,22 +40,14 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import com.sforce.ws.util.FileUtil;
 import junit.framework.Assert;
 
 public class CodeGeneratorTestUtil {
     private static final String NL = System.getProperty("line.separator");
     
     public static String getSourceAsStr(final File src) throws IOException {
-        FileInputStream stream = new FileInputStream(src);
-        try {
-          FileChannel fc = stream.getChannel();
-          MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-          /* Instead of using default, pass in a decoder. */
-          return Charset.defaultCharset().decode(bb).toString();
-        }
-        finally {
-          stream.close();
-        }
+        return FileUtil.toString(src);
     }
 
     public static File getFileFromResource(final String resource) throws URISyntaxException {

--- a/src/test/java/com/sforce/ws/codegen/ComplexTypeCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/ComplexTypeCodeGeneratorTest.java
@@ -135,6 +135,8 @@ public class ComplexTypeCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(Generator.TYPE);
         assertNotNull(template);
         template.add("gen", classMetadata);
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
 }

--- a/src/test/java/com/sforce/ws/codegen/ConnectionCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/ConnectionCodeGeneratorTest.java
@@ -159,6 +159,8 @@ public class ConnectionCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(wsdlc.CONNECTION);
         assertNotNull(template);
         template.add("gen", connectionClassMetadata);
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
 }

--- a/src/test/java/com/sforce/ws/codegen/ConnectorCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/ConnectorCodeGeneratorTest.java
@@ -46,6 +46,8 @@ public class ConnectorCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(wsdlc.CONNECTOR);
         assertNotNull(template);
         template.add("gen", new ConnectorMetadata(packageName, className, endpoint));
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
 }

--- a/src/test/java/com/sforce/ws/codegen/SObjectCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/SObjectCodeGeneratorTest.java
@@ -43,6 +43,8 @@ public class SObjectCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(Generator.SOBJECT);
         assertNotNull(template);
         template.add("gen", new ClassMetadata("com.sforce.soap.partner.sobject", null));
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
 }

--- a/src/test/java/com/sforce/ws/codegen/SimpleTypeCodeGeneratorTest.java
+++ b/src/test/java/com/sforce/ws/codegen/SimpleTypeCodeGeneratorTest.java
@@ -53,6 +53,8 @@ public class SimpleTypeCodeGeneratorTest extends TestCase {
         ST template = templates.getInstanceOf(Generator.SIMPLE_TYPE);
         assertNotNull(template);
         template.add("gen", new SimpleClassMetadata("com.sforce.soap.partner", "EmailSyncMatchPreference", enumEntries));
-        assertEquals(expectedSource, template.render());
+        String rendered = template.render();
+        rendered = rendered.replace("\r\n", "\n");
+        assertEquals(expectedSource, rendered);
     }
 }

--- a/src/test/java/com/sforce/ws/codegen/VoidReturnTest.java
+++ b/src/test/java/com/sforce/ws/codegen/VoidReturnTest.java
@@ -80,8 +80,9 @@ public class VoidReturnTest {
         });
 
         Assert.assertNotNull(generatedConnection.get());
-        Assert.assertEquals(CodeGeneratorTestUtil.getSourceAsStr(connection),
-                            CodeGeneratorTestUtil.getSourceAsStr(generatedConnection.get()));
+        String conSourceAsStr = CodeGeneratorTestUtil.getSourceAsStr(connection).replace("\r\n", "\n");
+        String generatedSrcAsStr = CodeGeneratorTestUtil.getSourceAsStr(generatedConnection.get()).replace("\r\n", "\n");
+        Assert.assertEquals(conSourceAsStr, generatedSrcAsStr);
     }
 
 }


### PR DESCRIPTION
I've made a variety of fixes and updates to fix a few issues, most notably being security scan failures with the owasp dependency checking tool but also including fixes for tests when run under windows and/or jdk 11+