### PR TITLE
adding back the constructor with 2 arguments

### DIFF
--- a/src/main/java/com/sforce/ws/tools/wsdlc.java
+++ b/src/main/java/com/sforce/ws/tools/wsdlc.java
@@ -167,6 +167,10 @@ public class wsdlc extends Generator {
         super(packagePrefix, templates, packagePrefix, javaTime);
     }
 
+    public wsdlc(String packagePrefix, STGroupDir templates) {
+        super(packagePrefix, templates, packagePrefix, false);
+    }
+
     private void generateConnectionClasses(Definitions definitions, File dir) throws IOException {
         ConnectionClassMetadata gen = new ConnectionMetadataConstructor(definitions, typeMapper, packagePrefix)
                 .getConnectionClassMetadata();


### PR DESCRIPTION
I am facing an issue while integrating wsc 49.0.0 release in Salesforce core. I believe the issue is caused by https://github.com/forcedotcom/wsc/commit/6698f255700b96142fbf81a658299ef27f4f6253 commit where we have added one more argument when instantiating wsdlc. In that commit, we are passing new arg javaTime as false in all existing calls to wsc.
