### PR TITLE
refactored Compiler.java class to use Java Compiler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ To skip the gpg signing, run the following command
 * `inputwsdlfile` is the name of the WSDL to generate stubs for.
 * `outputjarfile` is the name of the jar file to create from the WSDL.
 
-In case you run into a "ClassNotFoundException" try adding tools.jar to your class path
-
-    java -classpath "${JAVA_HOME}lib/tools.jar:target/force-wsc-49.0.0-uber.jar" com.sforce.ws.tools.wsdlc <inputwsdlfile>  <outputjarfile>
-
 ## Write Application Code
 The following sample illustrates creating a connection and creating a new Account SObject.  Login is automatically handled by the Connector.
 

--- a/src/main/java/com/sforce/ws/codegen/Generator.java
+++ b/src/main/java/com/sforce/ws/codegen/Generator.java
@@ -132,13 +132,13 @@ abstract public class Generator {
         }
     }
 
-    protected void compileTypes(File dir) throws ToolsException {
+    protected void compileTypes() throws ToolsException {
         Compiler compiler = new Compiler();
         List<String> fileNames = new ArrayList<String>();
         for (File f : javaFiles) {
             fileNames.add(f.getPath());
         }
-        compiler.compile(fileNames.toArray(new String[fileNames.size()]), dir);
+        compiler.compile(fileNames.toArray(new String[fileNames.size()]));
     }
 
     protected void generate(Definitions definitions, SfdcApiType sfdcApiType, Types types, File dir) throws IOException {

--- a/src/main/java/com/sforce/ws/tools/wsdlc.java
+++ b/src/main/java/com/sforce/ws/tools/wsdlc.java
@@ -126,7 +126,7 @@ public class wsdlc extends Generator {
         try {
             wsc.generate(wsdl, destDirectory);
             if (compile) {
-                wsc.compileTypes(destDirectory);
+                wsc.compileTypes();
                 wsc.generateJarFile(destJar, standAlone, destDirectory);
             }
         } finally {


### PR DESCRIPTION
Fix for issue https://github.com/forcedotcom/wsc/issues/222

We were dependent on tools.jar to get compiler class supplied within JDK and we were using reflection to use compile methods, however, with JDK9+, tools.jar are no longer provided and hence we are switching to use JavaCompiler API to locate and supply compiler for us to compile the autogenerated java stubs.

This fix has been tested locally with Enterprise.wsdl, Apex.wsdl, metadata.wsdl and Partner.wsdl and I have also tested the integration of this fix into core.