### PR TITLE
[WSC Specific] Make Jackson 2.18 and Exclude Meta-INF Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To skip the gpg signing, run the following command
     mvn clean package -Dgpg.skip
 
 ## Generating Stubs From WSDLs
-    java -jar target/force-wsc-64.0.2-uber.jar <inputwsdlfile> <outputjarfile>
+    java -jar target/force-wsc-64.0.3-uber.jar <inputwsdlfile> <outputjarfile>
 
 * `inputwsdlfile` is the name of the WSDL to generate stubs for.
 * `outputjarfile` is the name of the jar file to create from the WSDL.

--- a/pom.xml
+++ b/pom.xml
@@ -59,17 +59,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.17.1</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
@@ -142,6 +142,14 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>uber</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/22/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.force.api</groupId>
   <artifactId>force-wsc</artifactId>
   <packaging>jar</packaging>
-  <version>64.0.2</version>
+  <version>64.0.3</version>
   <name>force-wsc</name>
   <description>Force.com Web Service Connector</description>
   <url>http://www.force.com</url>


### PR DESCRIPTION
As per the requirements from the CARE team we want to update the Jackson to be 2.18 to ensure Spring 6.2 compatibility , also the spike mentions the path for it here : 
 https://docs.google.com/document/d/1l2gsz-v2FJOg8FsVdfsaFXBAi-P8TN4OqOJZyCH116o/edit?tab=t.0
 
 
 
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/819d9303-54cd-453b-a890-9f750c580c15" />
